### PR TITLE
make git history based assignee selection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@
 
 ## What does it mean?
 
-If you have CODEOWNERS file in the root of a Gerrit repository with GitHub users, issues will be autoassigned to random owners (in Gerrit!)
+If you have CODEOWNERS file in the root of a Gerrit repository with GitHub users, issues will be autoassigned to random
+owners (in Gerrit!)
 
 ## How to use it?
 
 Create a `CODEOWNERS` file in the root of your repository with the following syntax:
+
 ```
 path   @githubuser
 ...
@@ -48,7 +50,10 @@ https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-f
 
 ## Can I have less than 2 owners for one dir/repo?
 
-Yes, you can. (When `CODEOWNERS` exists, plugin may try to find other owners based on Git history..., this might be changed based on feedback...)
+Yes, you can.
+
+You can also choose to fill missing reviewers based on git history (use `#gerrit-codeowners.use-git-history: true`
+comment, to enable this feature)
 
 ## Can I have more than 2 owners?
 
@@ -85,7 +90,8 @@ Assignment is automatic:
 
 Just adopt code path!
 
-Just put your names to any `CODEOWNERS` for any path what you are comfortable with and give review when issues are assigned to you. :pray:
+Just put your names to any `CODEOWNERS` for any path what you are comfortable with and give review when issues are
+assigned to you. :pray:
 
 ## Oh, it doesn't work for me...
 

--- a/src/main/java/io/storj/gerrit/plugins/codeowners/ReviewAssigner.java
+++ b/src/main/java/io/storj/gerrit/plugins/codeowners/ReviewAssigner.java
@@ -105,7 +105,7 @@ public class ReviewAssigner implements WorkInProgressStateChangedListener, Comme
             final int splitIndex = owner.indexOf('/');
 
             //format of: @username
-            if(owner.startsWith("@")) {
+            if (owner.startsWith("@")) {
                 Integer accountId = findByUsername(owner.substring(1));
                 if (accountId != null) {
                     accounts.add(accountId);
@@ -114,7 +114,7 @@ public class ReviewAssigner implements WorkInProgressStateChangedListener, Comme
             }
 
             //format of: email@domain.com
-            if(splitIndex == -1) {
+            if (splitIndex == -1) {
                 Integer accountId = findByEmail(owner);
                 if (accountId != null) {
                     accounts.add(accountId);
@@ -132,9 +132,9 @@ public class ReviewAssigner implements WorkInProgressStateChangedListener, Comme
             GHOrganization organization = github.getOrganization(orgName);
             if (organization != null) {
                 GHTeam team = organization.getTeamBySlug(teamName);
-                if(team == null) {
+                if (team == null) {
                     log.warn(String.format("Github team couldn't be found: '%s/%s'", orgName, teamName));
-                } else if(team.getPrivacy() == GHTeam.Privacy.SECRET) {
+                } else if (team.getPrivacy() == GHTeam.Privacy.SECRET) {
                     log.warn(String.format("Github team is secret: '%s/%s'", orgName, teamName));
                 } else {
                     members.addAll(team.getMembers());
@@ -193,7 +193,7 @@ public class ReviewAssigner implements WorkInProgressStateChangedListener, Comme
             GHUser user = github.getUser(username);
             // then try to match by user email
             return this.findByEmail(user.getEmail());
-        } catch(Exception e) {
+        } catch (Exception e) {
             log.warn(e);
             return null;
         }
@@ -250,13 +250,13 @@ public class ReviewAssigner implements WorkInProgressStateChangedListener, Comme
             reviewers.remove(change.owner._accountId);
 
             int existingReviewers = 0;
-            if (change.reviewers != null && change.reviewers.get(ReviewerState.REVIEWER) != null){
+            if (change.reviewers != null && change.reviewers.get(ReviewerState.REVIEWER) != null) {
                 existingReviewers = change.reviewers.get(ReviewerState.REVIEWER).size();
             }
             missingReviewers = config.reviewerCount - existingReviewers;
 
             // if insufficient after populating from the owners file, attempt to augment with git history
-            if (reviewers.size() < config.reviewerCount) {
+            if (reviewers.size() < config.reviewerCount && config.useGitHistory) {
                 reviewers = fromGit(change.owner._accountId, reviewers, repo, revision.files.keySet(), missingReviewers);
             }
 

--- a/src/test/java/io/storj/codeowners/ConfigTest.java
+++ b/src/test/java/io/storj/codeowners/ConfigTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.util.regex.Matcher;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ConfigTest {
     @Test
@@ -62,6 +63,15 @@ public class ConfigTest {
 
         matcher = Config.REVIEWER_COUNT_PATTERN.matcher("#gerrit-codeownersxxx: 5");
         Assert.assertFalse(matcher.find());
+    }
+
+    @Test
+    public void geitHistoryEnabled() throws Exception {
+        final Config config = Config.parse(Files.lines(
+                Paths.get(ClassLoader.getSystemResource("TEST_CODEOWNERS4").toURI())
+        ));
+
+        assertTrue(config.useGitHistory);
     }
 
     @Test

--- a/src/test/resources/TEST_CODEOWNERS4
+++ b/src/test/resources/TEST_CODEOWNERS4
@@ -1,0 +1,2 @@
+# gerrit-codeowners.use-git-history: true
+* @storj/example


### PR DESCRIPTION
This gerrit plugin assigns issues based on CODEOWNER files. If there are not enough assignees, it may try to find one from  Github history.

This one can be confusing as it's not aware of ex-colleges or team structures.

This patch makes this feature optional.